### PR TITLE
Display CL Summit in Filecoin blue

### DIFF
--- a/events/consensus-lab-event.toml
+++ b/events/consensus-lab-event.toml
@@ -43,7 +43,7 @@ difficulty = "All Welcome"
 tags = ["Talks"]
 
 # a color, to group key events visually. use sparingly
-# color=""
+# color="blue"
 
 # A small logomark for the corner of the event
 logomark = "/logomarks/ConsensusLab-symbol-color.png"


### PR DESCRIPTION
I just learnt Filecoin-specific events are supposed to be coloured blue... This paints the CL summit.